### PR TITLE
add id-blacklist of 'self' to client config

### DIFF
--- a/lib/configs/client.js
+++ b/lib/configs/client.js
@@ -15,7 +15,7 @@ module.exports = {
 
   rules: {
     'camelcase': 2,
-    'consistent-this': [2, 'self'],
+    'id-blacklist': [2, 'self'],
     'strict': [2, 'function']
   }
 }


### PR DESCRIPTION
Half way through writing a lint for this, I found that this rule in eslint already exists.

cc @shane-tomlinson